### PR TITLE
fix incremental iceberg full refresh

### DIFF
--- a/dbt/include/glue/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/glue/macros/materializations/incremental/incremental.sql
@@ -20,10 +20,6 @@
   {%- set expire_snapshots = config.get('iceberg_expire_snapshots', 'True') -%}
   {%- set table_properties = config.get('table_properties', default='empty') -%}
 
-
-  {%- set full_refresh_config = config.get('full_refresh', default=False) -%}
-  {%- set full_refresh_mode = (flags.FULL_REFRESH == 'True' or full_refresh_config == 'True') -%}
-
   {% set target_relation = this %}
   {% set existing_relation_type = adapter.get_table_type(target_relation)  %}
   {% set tmp_relation = make_temp_relation(target_relation, '_tmp') %}
@@ -41,12 +37,6 @@
         {%- set hudi_options = config.get('hudi_options', default={}) -%}
         {{ adapter.hudi_merge_table(target_relation, sql, unique_key, partition_by, custom_location, hudi_options, substitute_variables) }}
         {% set build_sql = "select * from " + target_relation.schema + "." + target_relation.identifier + " limit 1 "%}
-  {% elif file_format == 'iceberg' %}
-        {{ adapter.iceberg_write(target_relation, sql, unique_key, partition_by, custom_location, strategy, table_properties) }}
-        {% set build_sql = "select * from glue_catalog." + target_relation.schema + "." + target_relation.identifier + " limit 1 "%}
-        {%- if expire_snapshots == 'True' -%}
-  	      {%- set result = adapter.iceberg_expire_snapshots(target_relation) -%}
-        {%- endif -%}
   {% else %}
       {% if strategy == 'insert_overwrite' and partition_by %}
         {% call statement() %}
@@ -57,17 +47,29 @@
         {% if file_format == 'delta' %}
             {{ adapter.delta_create_table(target_relation, sql, unique_key, partition_by, custom_location) }}
             {% set build_sql = "select * from " + target_relation.schema + "." + target_relation.identifier + " limit 1 " %}
+        {% elif file_format == 'iceberg' %}
+            {{ adapter.iceberg_write(target_relation, sql, unique_key, partition_by, custom_location, strategy, table_properties) }}
+            {% set build_sql = "select * from glue_catalog." + target_relation.schema + "." + target_relation.identifier + " limit 1 "%}
         {% else %}
             {% set build_sql = create_table_as(False, target_relation, sql) %}
         {% endif %}
-      {% elif existing_relation_type == 'view' or full_refresh_mode %}
+      {% elif existing_relation_type == 'view' or should_full_refresh() %}
         {{ drop_relation(target_relation) }}
         {% if file_format == 'delta' %}
             {{ adapter.delta_create_table(target_relation, sql, unique_key, partition_by, custom_location) }}
             {% set build_sql = "select * from " + target_relation.schema + "." + target_relation.identifier + " limit 1 " %}
+        {% elif file_format == 'iceberg' %}
+            {{ adapter.iceberg_write(target_relation, sql, unique_key, partition_by, custom_location, strategy, table_properties) }}
+            {% set build_sql = "select * from glue_catalog." + target_relation.schema + "." + target_relation.identifier + " limit 1 "%}
         {% else %}
             {% set build_sql = create_table_as(False, target_relation, sql) %}
         {% endif %}
+      {% elif file_format == 'iceberg' %}
+        {{ adapter.iceberg_write(target_relation, sql, unique_key, partition_by, custom_location, strategy, table_properties) }}
+        {% set build_sql = "select * from glue_catalog." + target_relation.schema + "." + target_relation.identifier + " limit 1 "%}
+        {%- if expire_snapshots == 'True' -%}
+  	      {%- set result = adapter.iceberg_expire_snapshots(target_relation) -%}
+        {%- endif -%}
       {% else %}
         {{ glue__create_tmp_table_as(tmp_relation, sql) }}
         {% set is_incremental = 'True' %}


### PR DESCRIPTION
Resolves #247

### Description

Fixing [full refresh with iceberg issue](https://github.com/aws-samples/dbt-glue/issues/247).

In the `incremental.sql` file, it was first checking if the relation was iceberg, instead of checking for full refresh.
See [athena connector implementation](https://github.com/dbt-athena/dbt-athena/blob/main/dbt/include/athena/macros/materializations/models/incremental/incremental.sql) for reference.

We fix it by modifying the order of the condition, we first check if the user has used the full refresh flag (i.e. `-f` or `--full-refresh`).

To check if the user used the flag, we use the dbt core macro [should_full_refresh()](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/include/global_project/macros/materializations/configs.sql#L6) instead of the currently implemented *full_refresh_mode* variable. Since we don't need the *full_refresh_mode* variable anymore, we remove this variable from the code.

Once the full refresh condition is True, we check if it is an iceberg materialization. If yes, we first delete the table using `glue__drop_relation` macro in adapters.sql. Then, we write the table with the `iceberg_write` function, that will re-create the table from scratch since it does not exist anymore.

TLDR:
- We modify the order of condition by first checking if full refresh is enabled instead of if iceberg.
- We check if full refresh is enabled with a dbt-core macro instead of custom implementation.
- If full refresh and iceberg, then we delete the table.
- We re-write the table using iceberg write.

### Checklist

- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
